### PR TITLE
Replaced std::cell::Ref with core::cell::Ref to fix no_std mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ use core::iter;
 use core::mem;
 use core::slice;
 use core::str;
-use std::cell::Ref;
+use core::cell::Ref;
 
 use mem::MaybeUninit;
 


### PR DESCRIPTION
The current code accidentally imports std::cell::Ref, which causes the code to fail to compile when the std feature is deactivated. I replaced this import with an import of core::cell::Ref, which accomplishes the same purpose while remaining compatible with no_std.